### PR TITLE
Compatibility with Tokio 1.0 Runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ readme = "README.md"
 
 [dependencies]
 influxdb-line-protocol = { git = "https://github.com/xoac/influxdb-line-protocol" }
-reqwest = { version = "0.10", default-features=false }
+reqwest = { version = "0.11", default-features=false }
 http = "0.2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
@@ -47,7 +47,7 @@ rustls = ["reqwest/rustls-tls"]
 json = ["reqwest/json"]
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3", features = ["default", "compat"] }
 futures_01 = { version = "0.1.25", package = "futures"}
 tokio_01 = { version = "0.1", package = "tokio" }

--- a/src/id.rs
+++ b/src/id.rs
@@ -30,7 +30,7 @@ impl FromStr for Id {
         if s.len() != ID_LEN {
             Err(IdErr::Parse)
         } else {
-            let v = u64::from_str_radix(&s, 16).map_err(|_| IdErr::Parse)?;
+            let v = u64::from_str_radix(s, 16).map_err(|_| IdErr::Parse)?;
             if v == 0 {
                 Err(IdErr::ZeroId)
             } else {


### PR DESCRIPTION
Awesome library! I just had one issue with not being able to get tokio to work with it (I already had tokio 1.0). 

Updating reqwest allows tokio 1.0 to be used with this library. 